### PR TITLE
修复空选项问题

### DIFF
--- a/selectorlibrary/src/main/java/com/bryant/selectorlibrary/SelectorView.java
+++ b/selectorlibrary/src/main/java/com/bryant/selectorlibrary/SelectorView.java
@@ -209,7 +209,7 @@ public class SelectorView extends ScrollView  {
             if (null == itemView) {
                 return;
             }
-            if (position == i) {
+            if (position == i && !TextUtils.isEmpty(itemView.getText().toString())) {
                 itemView.setTextColor(textcolor_selection);
             } else {
                 itemView.setTextColor(textcolor_unchecked);


### PR DESCRIPTION
当设置多个 item 时，会出现多余的一个空 item 。